### PR TITLE
perf: improve getHotelsByDestinationId api average latency

### DIFF
--- a/internal/repository/inmemory_hotel_repository.go
+++ b/internal/repository/inmemory_hotel_repository.go
@@ -7,20 +7,23 @@ import (
 
 // InMemoryHotelRepository uses one hashmaps to store keys that
 // are indexed by hotelId only. Filtering by destinationIds will
-// be doing a full table scan currently
+// be using a map<int, map<string, hotel>>
 type InMemoryHotelRepository struct {
-	kvStore map[string]*model.Hotel
-	mu      sync.Mutex
+	kvStore            map[string]*model.Hotel
+	destinationIdStore map[int]map[string]*model.Hotel
+	mu                 sync.Mutex
 }
 
 func NewInMemoryHotelRepository() *InMemoryHotelRepository {
 	m := make(map[string]*model.Hotel, 0)
+	destinationIdStore := make(map[int]map[string]*model.Hotel, 0)
 	return &InMemoryHotelRepository{
-		kvStore: m,
+		kvStore:            m,
+		destinationIdStore: destinationIdStore,
 	}
 }
 
-// GetHotelsByHotelId returns all the hotels given a list of hotelIds
+// GetHotelsByHotelIds returns all the hotels given a list of hotelIds
 // this function is thread-safe
 func (i *InMemoryHotelRepository) GetHotelsByHotelIds(hotelIds []string) []*model.Hotel {
 	i.mu.Lock()
@@ -40,20 +43,29 @@ func (i *InMemoryHotelRepository) GetHotelsByHotelIds(hotelIds []string) []*mode
 func (i *InMemoryHotelRepository) GetHotelsByDestinationId(destinationId int) []*model.Hotel {
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	var hotels []*model.Hotel
-	for _, val := range i.kvStore {
-		if val.DestinationID == destinationId {
-			hotels = append(hotels, val)
-		}
+	var hotelResult []*model.Hotel
+	allHotelsByDestinationId, _ := i.destinationIdStore[destinationId]
+	for _, val := range allHotelsByDestinationId {
+		hotelResult = append(hotelResult, val)
 	}
-	return hotels
+	return hotelResult
 }
 
 // InsertHotel inserts a hotel with the keys being both the hotelId and destinationId
 // this function is thread-safe
 func (i *InMemoryHotelRepository) InsertHotel(hotel *model.Hotel) {
 	i.mu.Lock()
+	defer i.mu.Unlock()
 	hotelIdKey := hotel.ID
 	i.kvStore[hotelIdKey] = hotel
-	i.mu.Unlock()
+	// we will have to check if map of map exist to guard against
+	// null value assignments i.e assigning to a null or empty map of maps
+	mapForDestinationId, present := i.destinationIdStore[hotel.DestinationID]
+	if present {
+		// update the object of hotelIds for this particular destinationId
+		mapForDestinationId[hotelIdKey] = hotel
+	} else {
+		// otherwise, insert a new map for this destinationId, with hotelId: hotel mapping
+		i.destinationIdStore[hotel.DestinationID] = map[string]*model.Hotel{hotelIdKey: hotel}
+	}
 }

--- a/internal/repository/inmemory_hotel_repository_test.go
+++ b/internal/repository/inmemory_hotel_repository_test.go
@@ -45,8 +45,7 @@ func TestInMemoryHotelRepository_InsertOneElement(t *testing.T) {
 	repo := NewInMemoryHotelRepository()
 	repo.InsertHotel(&hotelData1)
 	assert.Equal(t, *repo.kvStore[testHotelId1], hotelData1)
-	//assert.Equal(t, repo.destinationIdKvStore[hotelData1.DestinationID], []string{testHotelId1})
-	//assert.Nil(t, repo.hotelIdKvStore[testHotelId2])
+	assert.Equal(t, *repo.destinationIdStore[testSingleDestinationId][testHotelId1], hotelData1)
 }
 
 func TestInMemoryHotelRepository_InsertMultipleElementsWithSingleDestinationId(t *testing.T) {
@@ -55,7 +54,8 @@ func TestInMemoryHotelRepository_InsertMultipleElementsWithSingleDestinationId(t
 	repo.InsertHotel(&hotelData3)
 	assert.Equal(t, *repo.kvStore[hotelData2.ID], hotelData2)
 	assert.Equal(t, *repo.kvStore[hotelData3.ID], hotelData3)
-	//assert.Equal(t, repo.destinationIdKvStore[testMultipleDestinationId], []string{testHotelId2, testHotelId3})
+	assert.Equal(t, *repo.destinationIdStore[testMultipleDestinationId][testHotelId2], hotelData1)
+	assert.Equal(t, *repo.destinationIdStore[testMultipleDestinationId][testHotelId3], hotelData1)
 }
 
 func TestInMemoryHotelRepository_GetHotelWithSingleHotelId(t *testing.T) {

--- a/internal/repository/inmemory_hotel_repository_test.go
+++ b/internal/repository/inmemory_hotel_repository_test.go
@@ -54,8 +54,8 @@ func TestInMemoryHotelRepository_InsertMultipleElementsWithSingleDestinationId(t
 	repo.InsertHotel(&hotelData3)
 	assert.Equal(t, *repo.kvStore[hotelData2.ID], hotelData2)
 	assert.Equal(t, *repo.kvStore[hotelData3.ID], hotelData3)
-	assert.Equal(t, *repo.destinationIdStore[testMultipleDestinationId][testHotelId2], hotelData1)
-	assert.Equal(t, *repo.destinationIdStore[testMultipleDestinationId][testHotelId3], hotelData1)
+	assert.Equal(t, *repo.destinationIdStore[testMultipleDestinationId][testHotelId2], hotelData2)
+	assert.Equal(t, *repo.destinationIdStore[testMultipleDestinationId][testHotelId3], hotelData3)
 }
 
 func TestInMemoryHotelRepository_GetHotelWithSingleHotelId(t *testing.T) {


### PR DESCRIPTION
Load testing is run using k6.

**Before Commmit**

Config: 30VUS, Duration: 10s
<img width="811" alt="30vus" src="https://user-images.githubusercontent.com/13248466/222538842-ce1e9c60-a229-4a03-84ad-6fa36c1028cf.png">

Config: 100VUs, Duration: 10s
<img width="795" alt="100vus" src="https://user-images.githubusercontent.com/13248466/222538859-4d0b5073-ccf8-4bb3-b1df-b05f8bcaf833.png">

**After Commit:**

Config: 30VUS, Duration: 10s
<img width="827" alt="new30vus" src="https://user-images.githubusercontent.com/13248466/222538975-e3d86ec0-dc76-45de-8b25-fb6439f1cba5.png">

Config: 100VUS, Duration: 10s
<img width="825" alt="new100vus" src="https://user-images.githubusercontent.com/13248466/222539035-0714022a-b07d-40b9-ab44-4837d3d7c329.png">
